### PR TITLE
Support any uri scheme

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: ExtensionContext) {
 
   // options to control the language client
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{scheme: "file", language: "abap"}],
+    documentSelector: [{scheme: "file", language: "abap"}, {scheme: "adt", language: "abap"}],
     synchronize: {
     // notify the server about file changes to abaplint.json files contained in the workspace
       fileEvents: workspace.createFileSystemWatcher("**/abaplint.json"),

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: ExtensionContext) {
 
   // options to control the language client
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{scheme: "file", language: "abap"}, {scheme: "adt", language: "abap"}],
+    documentSelector: [{language: "abap"}],
     synchronize: {
     // notify the server about file changes to abaplint.json files contained in the workspace
       fileEvents: workspace.createFileSystemWatcher("**/abaplint.json"),


### PR DESCRIPTION
I think the restriction to file scheme was made by MS as the safest option, in case the server wants to read the file directly.

As long as you rely on the client sending the content, any scheme will work (well, except perhaps reading a json file from the root and things like that, I didn't check how you do that).

As fara s my extension is concerned this will only show bogus errors, but will work fine foe people serving an ABAPGIT repo over ftp and things like that.

My own test with the extension looks like this:

![image](https://user-images.githubusercontent.com/2453277/49685726-94bf8d80-fae0-11e8-8b01-819bfd083ea7.png)

message is bogus (I mean correct, but useless for someone writing code), but linter did work