### PR TITLE
fix artifact creation with command palette

### DIFF
--- a/client/src/create.ts
+++ b/client/src/create.ts
@@ -15,6 +15,17 @@ async function createFile(uri: vscode.Uri, content: string) {
 }
 
 async function findFolder(uri: vscode.Uri) {
+  // URI is undefined when the command palette is used to create artifacts
+  if (!uri) {
+    // fallback logic: folder of currently opened window (if it is in the workspace), otherwise root of workspace
+    const activeWindowUri = vscode.window.activeTextEditor?.document.uri;
+    if (activeWindowUri && vscode.workspace.getWorkspaceFolder(activeWindowUri)){
+      uri = activeWindowUri;
+    } else {
+      return vscode.workspace.rootPath + path.sep;
+    }
+  }
+
   const parsed = path.parse(uri.fsPath);
   const stat = await vscode.workspace.fs.stat(uri);
   return stat.type === vscode.FileType.File ?
@@ -23,6 +34,9 @@ async function findFolder(uri: vscode.Uri) {
 }
 
 async function fileExists(uri: vscode.Uri): Promise<boolean> {
+  if (!uri) {
+    return false;
+  }
   try {
     await vscode.workspace.fs.stat(uri);
     return true;


### PR DESCRIPTION
fallback: folder of currently opened window (if it is in the current
workspace), otherwise root path of workspace

closes #72 